### PR TITLE
add boost 1.81.0

### DIFF
--- a/cmake/projects/Boost/hunter.cmake
+++ b/cmake/projects/Boost/hunter.cmake
@@ -247,6 +247,17 @@ hunter_add_version(
     7ccc47e82926be693810a687015ddc490b49296d
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    Boost
+    VERSION
+    "1.81.0"
+    URL
+    "${_hunter_boost_base_url}/1.81.0/source/boost_1_81_0.tar.bz2"
+    SHA1
+    898469f1ae407f5cbfca84f63ad602962eebf4cc
+)
+
 # up until 1.63 sourcefourge was used
 set(_hunter_boost_base_url "https://downloads.sourceforge.net/project/boost/boost/")
 hunter_add_version(


### PR DESCRIPTION
I branched off of incubator-2022-01-26_02 (used by our project) and added this new branch, 2023-03-29_01.

I don't want to merge this to master branch, just have a new branch in this repo.