### PR TITLE
add spdlog 1.11.0

### DIFF
--- a/cmake/projects/spdlog/hunter.cmake
+++ b/cmake/projects/spdlog/hunter.cmake
@@ -134,11 +134,11 @@ hunter_add_version(
     PACKAGE_NAME
     spdlog
     VERSION
-    "1.11.0"
+    "1.11.0-p2"
     URL
-    "https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.zip"
+    "https://github.com/gitlw/spdlog/archive/refs/tags/1.11.0-p2.zip"
     SHA1
-    4075d3da589d2000cffbd53ea8d31715a64ff8c6
+    0a6afe1baba6b7ee2f6e61ff3c63ef742edaa21e
 )
 
 hunter_cmake_args(

--- a/cmake/projects/spdlog/hunter.cmake
+++ b/cmake/projects/spdlog/hunter.cmake
@@ -130,6 +130,17 @@ hunter_add_version(
     3bfb2352482e6190c377f121b1f760dad767b58d
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    spdlog
+    VERSION
+    "1.11.0"
+    URL
+    "https://github.com/gabime/spdlog/archive/refs/tags/v1.11.0.zip"
+    SHA1
+    4075d3da589d2000cffbd53ea8d31715a64ff8c6
+)
+
 hunter_cmake_args(
     spdlog
     CMAKE_ARGS


### PR DESCRIPTION
<!--- Use this part of template if you're adding new package. Remove the rest. -->
add spdlog version 1.11.0 to address the bug https://github.com/gabime/spdlog/issues/1680

The referenced spdlog library is forked from https://github.com/gabime/spdlog, and then has HunterGate support added.
The changes made on top of the official spdlog release can be viewed at
https://github.com/gitlw/spdlog/compare/v1.x..v1.11.0-p2