### PR TITLE
Add fmt version 9.1.0

### DIFF
--- a/cmake/projects/fmt/hunter.cmake
+++ b/cmake/projects/fmt/hunter.cmake
@@ -118,6 +118,17 @@ hunter_add_version(
     59bea0bd88e72ac2769c57d584b0cbed956038cf
 )
 
+hunter_add_version(
+    PACKAGE_NAME
+    fmt
+    VERSION
+    "9.1.0"
+    URL
+    "https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz"
+    SHA1
+    6c0db60f3fa7bd4cf58edc777a2408e0ddfb28b9
+)
+
 hunter_cmake_args(
     fmt
     CMAKE_ARGS


### PR DESCRIPTION
Adding fmt version 9.1.0 to support spdlog 1.11.0.

Testing done:
Verified that fmt 9.1.0 and spdlog 1.11.0 works together.